### PR TITLE
Fix issue rfxn/linux-malware-detect#84

### DIFF
--- a/files/internals/functions
+++ b/files/internals/functions
@@ -1554,7 +1554,7 @@ monitor_init() {
                 fi
         fi
 
-	$nice_command $inotify -d -r -o $inotify_log --fromfile $inotify_fpaths $exclude --timefmt "%d %b %H:%M:%S" --format "%w%f %e %T" -m -e create,move,modify >> /dev/null 2>&1 &
+	$nice_command $inotify -r --fromfile $inotify_fpaths $exclude --timefmt "%d %b %H:%M:%S" --format "%w%f %e %T" -m -e create,move,modify >> $inotify_log 2>&1 &
 	sleep 2
 	inotify_pid=`$pidof inotifywait`
 	if [ -z "$inotify_pid" ]; then


### PR DESCRIPTION
inotifywait doesn't support -d and -o options in Centos 6 and Ubuntu 12. This solution provided by @maxxer solves the issue and should work for everyone.
